### PR TITLE
fix test when source is a directory

### DIFF
--- a/python_sdist
+++ b/python_sdist
@@ -58,7 +58,7 @@ if __name__ == "__main__":
         args.basename = files[0]
 
     cur_dir = os.getcwd()
-    if tarfile.is_tarfile(args.basename):
+    if os.path.isfile(args.basename) and tarfile.is_tarfile(args.basename):
         # The tar_scm source service usually provides a tarball, so we have to extract
         # that first before we can chdir() into it.
         tf = tarfile.open(args.basename)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/lib/obs/service/python_sdist", line 61, in <module>
    if tarfile.is_tarfile(args.basename):
  File "/usr/lib64/python2.7/tarfile.py", line 2624, in is_tarfile
    t = open(name)
  File "/usr/lib64/python2.7/tarfile.py", line 1675, in open
    return func(name, "r", fileobj, **kwargs)
  File "/usr/lib64/python2.7/tarfile.py", line 1740, in gzopen
    fileobj = gzip.GzipFile(name, mode, compresslevel, fileobj)
  File "/usr/lib64/python2.7/gzip.py", line 94, in __init__
    fileobj = self.myfileobj = __builtin__.open(filename, mode or 'rb')
IOError: [Errno 21] Is a directory: 'example-basename'
```